### PR TITLE
Correct a typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Press shift+alt+a to remove all highlights.
 
 ## Extension Settings
 
-`rainbow-highlighter.pallete`: Set of colors that will be used for highlighting.  
+`rainbow-highlighter.palette`: Set of colors that will be used for highlighting.  
 `rainbow-highlighter.background-alpha`: If you're using background, this value will be the alpha value for background.  
 `rainbow-highlighter.use-border`: Use border rather than background, like gif above.
 


### PR DESCRIPTION
[pallete](https://github.com/cobaltblu27/rainbow-highlighter/blame/master/README.md#L16) to palette ([highlighter.ts:27](https://github.com/cobaltblu27/rainbow-highlighter/blame/d3f04c8c09d42642e86c8d8325179f9d036ffda0/src/highlighter.ts#L27))